### PR TITLE
Content ID consistency

### DIFF
--- a/_deconst.json
+++ b/_deconst.json
@@ -1,3 +1,3 @@
 {
-  "contentIDBase": "https://github.com/rackerlabs/docs-containers"
+  "contentIDBase": "https://github.com/rackerlabs/docs-container-service"
 }


### PR DESCRIPTION
Keeping the content ID base up to date with the repo name, just to avoid confusion.
