### PR TITLE
Enable Jekyll Assets Plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
-# A sample Gemfile
 source "https://rubygems.org"
 
-# gem "rails"
 gem "jekyll"
+gem "jekyll-assets"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.3.8)
     blankslate (2.1.2.4)
     celluloid (0.16.0)
       timers (~> 4.0.0)
@@ -13,7 +14,10 @@ GEM
     colorator (0.1)
     execjs (2.5.2)
     fast-stemmer (1.0.2)
+    fastimage (1.6.8)
+      addressable (~> 2.3, >= 2.3.5)
     ffi (1.9.10)
+    hike (1.2.3)
     hitimes (1.2.2)
     jekyll (2.5.3)
       classifier-reborn (~> 2.0)
@@ -30,6 +34,14 @@ GEM
       redcarpet (~> 3.1)
       safe_yaml (~> 1.0)
       toml (~> 0.1.0)
+    jekyll-assets (0.14.0)
+      fastimage (~> 1.6)
+      jekyll (~> 2.0)
+      mini_magick (~> 4.1)
+      sass (~> 3.2)
+      sprockets (~> 2.10)
+      sprockets-helpers
+      sprockets-sass
     jekyll-coffeescript (1.0.1)
       coffee-script (~> 2.2)
     jekyll-gist (1.2.1)
@@ -45,18 +57,32 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     mercenary (0.3.5)
+    mini_magick (4.2.1)
+    multi_json (1.11.0)
     parslet (1.5.0)
       blankslate (~> 2.0)
     posix-spawn (0.3.11)
     pygments.rb (0.6.3)
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.2.0)
+    rack (1.6.0)
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     redcarpet (3.2.3)
     safe_yaml (1.0.4)
     sass (3.4.13)
+    sprockets (2.12.3)
+      hike (~> 1.2)
+      multi_json (~> 1.0)
+      rack (~> 1.0)
+      tilt (~> 1.1, != 1.3.0)
+    sprockets-helpers (1.1.0)
+      sprockets (~> 2.0)
+    sprockets-sass (1.3.1)
+      sprockets (~> 2.0)
+      tilt (~> 1.1)
+    tilt (1.4.1)
     timers (4.0.1)
       hitimes
     toml (0.1.2)
@@ -68,6 +94,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll
+  jekyll-assets
 
 BUNDLED WITH
    1.10.6

--- a/_config.yml
+++ b/_config.yml
@@ -31,3 +31,7 @@ defaults:
       path: "docs"
     values:
       layout: "page"
+
+assets:
+  sources:
+  - _assets/img

--- a/_plugins/jekyll_assets.rb
+++ b/_plugins/jekyll_assets.rb
@@ -1,0 +1,1 @@
+require 'jekyll-assets'


### PR DESCRIPTION
This uses the same config as the dev blog so that we can include images in `_assets/img` with the `asset_path` tag.
