### PR TITLE
Restore redcarpet as the Markdown renderer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ description: >
 
 baseurl: "" # the subpath of your site, e.g. /blog/
 # Build settings
+markdown: redcarpet
 
 exclude:
   - script


### PR DESCRIPTION
#58 switched the markdown renderer to Jekyll's default of kramdown, but this broke some must-have features like fenced code blocks. Back to redcarpet it is :hammer:

Fixes #63.
