### PR TITLE
Use permalink instead of slug

### DIFF
--- a/_tutorials/000-tutorial-101-template.md
+++ b/_tutorials/000-tutorial-101-template.md
@@ -2,7 +2,7 @@
 title: Tutorial name
 author: First Last <first.last@rackspace.com>
 date: 2015-09-28
-slug: tutorial-name
+permalink: docs/tutorials/tutorial-name/
 description: Do a thing on RCS
 docker-versions:
   - 1.8.2

--- a/_tutorials/000-tutorial-concept-template.md
+++ b/_tutorials/000-tutorial-concept-template.md
@@ -2,7 +2,7 @@
 title: Tutorial name
 author: First Last <first.last@rackspace.com>
 date: 2015-09-28
-slug: tutorial-name
+permalink: docs/tutorials/tutorial-name/
 description: Do a thing on RCS
 docker-versions:
   - 1.8.2

--- a/_tutorials/000-tutorial-task-template.md
+++ b/_tutorials/000-tutorial-task-template.md
@@ -2,7 +2,7 @@
 title: Tutorial name
 author: First Last <first.last@rackspace.com>
 date: 2015-09-28
-slug: tutorial-name
+permalink: docs/tutorials/tutorial-name/
 description: Do a thing on RCS
 docker-versions:
   - 1.8.2

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ layout: default
       <h3>Tutorials</h3>
       <ul>
         {% for tutorial in site.tutorials %}
-          <li><a href="{{ tutorial.url }}">{{ tutorial.title }}</a></li>
+          <li><a href="{{ site.baseurl }}{{ tutorial.url }}">{{ tutorial.title }}</a></li>
         {% endfor %}
       </ul>
     </div>
@@ -15,7 +15,7 @@ layout: default
       <h3>Best Practices</h3>
       <ul>
         {% for bp in site.best-practices %}
-          <li><a href="{{ bp.url }}">{{ bp.title }}</a></li>
+          <li><a href="{{ site.baseurl }}{{ bp.url }}">{{ bp.title }}</a></li>
         {% endfor %}
       </ul>
     </div>
@@ -23,7 +23,7 @@ layout: default
       <h3>References</h3>
       <ul>
         {% for reference in site.references %}
-          <li><a href="{{ reference.url }}">{{ reference.title }}</a></li>
+          <li><a href="{{ site.baseurl }}{{ reference.url }}">{{ reference.title }}</a></li>
         {% endfor %}
       </ul>
     </div>


### PR DESCRIPTION
The front matter `slug` isn't supported so we are using `permalink` instead. With permalink
you must specify the entire relative path, e.g. `permalink: docs/references/file-name/`, ending with a slash. Do not start with a leading slash.

Since permalink affects how the `post.url` value is set, I've tweaked the index page to use `site.baseurl` so that if we set that in the future, things will still work.
