### PR TITLE
Instructions to load Docker environment on Linux and Mac OS X

### DIFF
--- a/_references/rcs-credentials.md
+++ b/_references/rcs-credentials.md
@@ -26,7 +26,7 @@ using the credentials to authenticate to your cluster.
 
 2. Click the gear icon next to your cluster name and select **Download Credentials**.
 
-    ![Cluster Context Menu &rarr; Download Credentials]({% asset_path rcs-credentials/download-credentials.png %})
+    ![Cluster Context Menu > Download Credentials]({% asset_path rcs-credentials/download-credentials.png %})
 
 3. When prompted, click **Download File**.
 
@@ -44,7 +44,7 @@ using the credentials to authenticate to your cluster.
 
 6. Load your credentials and use them to interact with your cluster:
   * (_Linux and Mac OSX users_) Run `source docker.env`.
-  * (_Windows users_) See [Load Docker environment from the command-line on Windows](/docs/tutorials/load-docker-environment-on-windows/).
+  * (_Windows users_) See [Load Docker environment from the command line on Windows](/docs/tutorials/load-docker-environment-on-windows/).
 
 ### <a name="windows"></a> Create a Windows script
 The cluster credentials zip file includes a Bash script, **docker.env**,

--- a/_references/troubleshooting-port-unavailable.md
+++ b/_references/troubleshooting-port-unavailable.md
@@ -67,7 +67,7 @@ on the cluster to add capacity.
 1. Log in to the control panel at [https://mycluster.rackspacecloud.com](https://mycluster.rackspacecloud.com).
 2. Click the gear icon next to the cluster and select **Grow Cluster**.
 
-    ![Cluster Action Menu &rarr; Grow Cluster]({% asset_path troubleshooting-port-unavailable/grow-cluster.png %})
+    ![Cluster Action Menu > Grow Cluster]({% asset_path troubleshooting-port-unavailable/grow-cluster.png %})
 
 Otherwise, you can use Docker Machine to add a node to the Docker Swarm cluster.
 See the Docker Machine documentation for additional information about [how to manage

--- a/_tutorials/load-docker-environment-on-linux.md
+++ b/_tutorials/load-docker-environment-on-linux.md
@@ -1,9 +1,9 @@
 ---
-title: Load a Docker environment from the command-line on Linux
+title: Load a Docker environment from the command line on Linux
 author: Carolyn Van Slyck <carolyn.vanslyck@rackspace.com>
 date: 2015-09-30
 permalink: docs/tutorials/load-docker-environment-on-linux/
-description: Learn to load a Rackspace Container Service Docker environment on Linux, so that you can work with your Docker cluster from the command-line
+description: Learn how to load a Rackspace Container Service Docker environment on Linux, so that you can work with your Docker cluster from the command line
 docker-versions:
   - 1.8.2
 topics:
@@ -17,18 +17,15 @@ topics:
 
 This tutorial describes how to load a Docker environment on Linux.
 
-### <a name="prerequisites"></a> Prerequisites
+### <a name="prerequisites"></a> Prerequisite
 
 [Docker](https://docs.docker.com/installation/ubuntulinux/)
 
-#### <a name="steps"></a> Steps
-To load a Docker environment, perform the following steps:
+#### <a name="load"></a> Load the Docker environment
 
 1. Open a command terminal.
-2. Load your Docker host environment variables by using one of the following methods:
-  * If you are using the Rackspace Container Service, follow the instructions on [Working with Your Cluster Credentials][get-cluster-creds]
-    to download your credentials. Then, run `source docker.env`.
-  * Otherwise, no additional setup is required.
+2. If you are using the Rackspace Container Service, [download your credentials][get-cluster-creds].
+    Then, run `source docker.env`.
 3. Verify that your Docker environment was initialized properly by running `docker version`.
 
 [get-cluster-creds]: {{site.baseurl}}/docs/references/rcs-credentials/

--- a/_tutorials/load-docker-environment-on-mac.md
+++ b/_tutorials/load-docker-environment-on-mac.md
@@ -1,9 +1,9 @@
 ---
-title: Load a Docker environment from the command-line on Mac OS X
+title: Load a Docker environment from the command line on Mac OS X
 author: Carolyn Van Slyck <carolyn.vanslyck@rackspace.com>
 date: 2015-09-30
 permalink: docs/tutorials/load-docker-environment-on-mac/
-description: Learn to load a Docker environment on Mac OS X, so that you can work with Docker from the command-line
+description: Learn how to load a Docker environment on Mac OS X, so that you can work with Docker from the command line
 docker-versions:
   - 1.8.2
 topics:
@@ -17,17 +17,15 @@ topics:
 
 This tutorial describes how to load a Docker environment on Mac OS X.
 
-### <a name="prerequisites"></a> Prerequisites
+### <a name="prerequisites"></a> Prerequisite
 
 [Docker Toolbox](https://www.docker.com/toolbox)
 
-#### <a name="steps"></a> Steps
-To load a Docker environment, perform the following steps:
-
+#### <a name="load"></a> Load the Docker environment
 1. Open a command terminal.
 2. Load your Docker host environment variables by using one of the following methods:
-  * If you are using the Rackspace Container Service, follow the instructions on [Working with Your Cluster Credentials][get-cluster-creds]
-    to download your credentials. Then, run `source docker.env`.
+  * If you are using the Rackspace Container Service, [download your credentials][get-cluster-creds].
+    Then, run `source docker.env`.
   * Otherwise, run `eval $(docker-machine env default --shell bash)`,
     replacing `default` with the name of your Docker host.
 3. Verify that your Docker environment was initialized properly by running `docker version`.

--- a/_tutorials/load-docker-environment-on-windows.md
+++ b/_tutorials/load-docker-environment-on-windows.md
@@ -1,5 +1,5 @@
 ---
-title: Load a Docker environment from the command-line on Windows
+title: Load a Docker environment from the command line on Windows
 author: Carolyn Van Slyck <carolyn.vanslyck@rackspace.com>
 date: 2015-09-30
 permalink: docs/tutorials/load-docker-environment-on-windows/
@@ -30,7 +30,7 @@ text commands and _terminal_ is the graphical window that hosts a shell.
   * [Mintty](#mintty)
   * [Alternatives](#alternatives)
 
-### <a name="prerequisites"></a> Prerequisites
+### <a name="prerequisites"></a> Prerequisite
 
 [Docker Toolbox](https://www.docker.com/toolbox)
 
@@ -49,8 +49,8 @@ CMD, perform the following steps:
 
 1. Run `cmd.exe`.
 2. Load your Docker host environment variables by using one of the following methods:
-  * If you are using the Rackspace Container Service, follow the instructions in [Working with Your Cluster Credentials][get-cluster-creds]
-    to download your credentials. Then, run `docker.cmd`.
+  * If you are using the Rackspace Container Service, [download your credentials][get-cluster-creds].
+    Then, run `docker.cmd`.
   * Otherwise, run `docker-machine env default --shell cmd`, replacing `default`
     with the name of your Docker host. Copy the command output, and then paste it into the command line.
 3. Verify that your Docker environment was initialized properly by running `docker version`.
@@ -65,8 +65,8 @@ Windows supported by Docker. To load a Docker environment in PowerShell, perform
 
 1. Run `powershell.exe`.
 2. Load your Docker host environment variables by using one of the following methods:
-  * If you are using the Rackspace Container Service, follow the instructions on [Working with Your Cluster Credentials][get-cluster-creds]
-    to download your credentials. Then, run `docker.ps1`.
+  * If you are using the Rackspace Container Service, [download your credentials][get-cluster-creds].
+    Then, run `docker.ps1`.
   * Otherwise, run `docker-machine env default --shell powershell | Invoke-Expression`,
     replacing `default` with the name of your Docker host.
 3. Verify that your Docker environment was initialized properly by running `docker version`.
@@ -88,8 +88,8 @@ To load a Docker environment in Bash, perform the following steps:
     * In Windows Explorer, right-click a directory and select **Git Bash Here**.
     * From a terminal, run `"C:\Program Files\Git\bin\bash.exe" --login -i`.
 2. Load your Docker host environment variables by using one of the following methods:
-  * If you are using the Rackspace Container Service, follow the instructions on [Working with Your Cluster Credentials][get-cluster-creds]
-    to download your credentials. Then, run `source docker.env`.
+  * If you are using the Rackspace Container Service, [download your credentials][get-cluster-creds].
+    Then, run `source docker.env`.
   * Otherwise, run `eval $(docker-machine env default --shell bash)`,
     replacing `default` with the name of your Docker host.
 3. Verify that your Docker environment was initialized properly by running `docker version`.
@@ -149,7 +149,7 @@ Windows terminal used by CMD and PowerShell.
 1. [Download ConsoleZ from GitHub][consolez-downloads].
 2. Unzip the files to any location, such as **C:\Program Files\ConsoleZ**.
 3. Open `console.exe`.
-4. To customize ConsoleZ, right-click and select **Edit &rarr; Settings**. You can
+4. To customize ConsoleZ, right-click and select **Edit > Settings**. You can
     set the default shell, configure tabs, appearance, and so on.
 
 In the following screenshot, ConsoleZ is configured with tabs for each shell (CMD, Bash and PowerShell).


### PR DESCRIPTION
Originally we only had instructions for how to use docker.env and docker-machine for Windows. However it would be helpful to have instructions for all supported operating systems so that they can be linked to from other tutorials.
