### PR TITLE
Start a humans.txt

### DIFF
--- a/humans.txt
+++ b/humans.txt
@@ -1,0 +1,7 @@
+---
+---
+/* TEAM */
+
+  Platform Wrangler: Ash Wilson
+  Site: https://azurefire.net/
+  Location: Gambrills, MD


### PR DESCRIPTION
This adds a [`/humans.txt`](http://humanstxt.org/) entry to the site. It's a neat, informal way to tell the world who built the thing they're looking at, and a bit of an easter egg to find for people who know to look for it.

I've only added myself for now because it felt presumptuous to add other people in. You can all send PRs to this PR, or we can merge this and everyone can add themselves whenever they feel like it.