### PR TITLE
Flag *.txt and *.xml as unsearchable.

### DIFF
--- a/blog/atom.xml
+++ b/blog/atom.xml
@@ -1,4 +1,5 @@
 ---
+unsearchable: true
 content_type: text/xml
 ---
 <?xml version="1.0" encoding="utf-8"?>

--- a/humans.txt
+++ b/humans.txt
@@ -1,4 +1,5 @@
 ---
+unsearchable: true
 ---
 /* TEAM */
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,4 @@
 ---
+unsearchable: true
 ---
 User-agent: *


### PR DESCRIPTION
This will exclude them from Elasticsearch indexing and keep us from showing really weird results.