### PR TITLE
Remove `authorAvatar` from 7-Dec-2015 post

### DIFF
--- a/_posts/2015-12-07-deploying-secure-web-applications-rackspace-cloud-carina-docker.markdown
+++ b/_posts/2015-12-07-deploying-secure-web-applications-rackspace-cloud-carina-docker.markdown
@@ -5,7 +5,6 @@ date: 2015-12-07 23:59
 comments: true
 author: Lars Butler <lars.butler@rackspace.com>
 authorIsRacker: true
-authorAvatar: https://secure.gravatar.com/avatar/d7ed4dc5ad80ffecb3aed70fc7190e52
 published: true
 categories:
     - DevOps


### PR DESCRIPTION
The gravatar image is pulled from the author's email address. I
originally added the `authorAvatar` to try and fix the absence of my
avatar image from the post, but that was the wrong fix. Instead, I
simply added my author email address to my gravatar profile and that
fixed the problem.