### PR TITLE
simplify concluding suggestion to read Carina doc

### DIFF
--- a/_ecosystem/2015-10-12-docker-best-practices-image-repository.md
+++ b/_ecosystem/2015-10-12-docker-best-practices-image-repository.md
@@ -87,7 +87,11 @@ Other recommended reading:
 
 - [CoreOS’ Quay.io](https://quay.io/)
 
-The purpose of this article is to help you understand Carina by introducing you to the ecosystem of container-related tools. You can begin learning about Carina itself at
+The purpose of this article is to help you understand Carina by introducing you
+to the ecosystem of container-related tools.
+To begin learning about Carina itself, see
+[Overview of Carina]({{ site.baseurl }}docs/overview-of-carina/).
+To begin using Carina, see
 [Getting started on Carina]({{ site.baseurl }}/docs/getting-started/getting-started-on-carina/).
 
 ### About the author

--- a/_ecosystem/2015-10-12-docker-best-practices-image-repository.md
+++ b/_ecosystem/2015-10-12-docker-best-practices-image-repository.md
@@ -87,14 +87,8 @@ Other recommended reading:
 
 - [CoreOS’ Quay.io](https://quay.io/)
 
-In addition to *best-practices* articles such as this one,
-Carina documentation includes *getting started* guidance and *tutorials*:
-
-* For information about Carina by Rackspace and getting started
-  with clusters and containers, explore the *​getting started​* collection.
-* For step-by-step demonstrations and instructions, explore the *tutorials* collection.
-* For discussions of key ideas, recommendations of useful methods and tools, and
-  general good advice, explore the *best-practices* collection.
+The purpose of this article is to help you understand Carina by introducing you to the ecosystem of container-related tools. You can begin learning about Carina itself at
+[Getting started on Carina]({{ site.baseurl }}/docs/getting-started/getting-started-on-carina/).
 
 ### About the author
 

--- a/_ecosystem/2015-10-13-docker-best-practices-dockerfile.md
+++ b/_ecosystem/2015-10-13-docker-best-practices-dockerfile.md
@@ -193,14 +193,12 @@ Other recommended reading:
 
 - <http://www.busybox.net/about.html>
 
-In addition to *best-practices* articles such as this one,
-Carina documentation includes *getting started* guidance and *tutorials*:
-
-* For information about Carina by Rackspace and getting started
-  with clusters and containers, explore the *​getting started​* collection.
-* For step-by-step demonstrations and instructions, explore the *tutorials* collection.
-* For discussions of key ideas, recommendations of useful methods and tools, and
-  general good advice, explore the *best-practices* collection.
+The purpose of this article is to help you understand Carina by introducing you
+to the ecosystem of container-related tools.
+To begin learning about Carina itself, see
+[Overview of Carina]({{ site.baseurl }}docs/overview-of-carina/).
+To begin using Carina, see
+[Getting started on Carina]({{ site.baseurl }}/docs/getting-started/getting-started-on-carina/).
 
 ### About the author
 

--- a/_ecosystem/2015-10-14-docker-best-practices-data-stateful-applications.md
+++ b/_ecosystem/2015-10-14-docker-best-practices-data-stateful-applications.md
@@ -206,14 +206,12 @@ Other recommended reading:
 
 - [Introduction to container technologies: orchestration and management of container clusters](../container-technologies-orchestration-clusters/)
 
-In addition to *best-practices* articles such as this one,
-Carina documentation includes *getting started* guidance and *tutorials*:
-
-* For information about Carina by Rackspace and getting started
-  with clusters and containers, explore the *​getting started​* collection.
-* For step-by-step demonstrations and instructions, explore the *tutorials* collection.
-* For discussions of key ideas, recommendations of useful methods and tools, and
-  general good advice, explore the *best-practices* collection.
+The purpose of this article is to help you understand Carina by introducing you
+to the ecosystem of container-related tools.
+To begin learning about Carina itself, see
+[Overview of Carina]({{ site.baseurl }}docs/overview-of-carina/).
+To begin using Carina, see
+[Getting started on Carina]({{ site.baseurl }}/docs/getting-started/getting-started-on-carina/).
 
 ### About the author
 

--- a/_ecosystem/2015-10-15-docker-best-practices-container-linking.md
+++ b/_ecosystem/2015-10-15-docker-best-practices-container-linking.md
@@ -135,14 +135,12 @@ Other recommended reading:
 
 - [Introduction to container technologies: registration and discovery of container services](../container-technologies-registration-discover/)
 
-In addition to *best-practices* articles such as this one,
-Carina documentation includes *getting started* guidance and *tutorials*:
-
-* For information about Carina by Rackspace and getting started
-  with clusters and containers, explore the *​getting started​* collection.
-* For step-by-step demonstrations and instructions, explore the *tutorials* collection.
-* For discussions of key ideas, recommendations of useful methods and tools, and
-  general good advice, explore the *best-practices* collection.
+The purpose of this article is to help you understand Carina by introducing you
+to the ecosystem of container-related tools.
+To begin learning about Carina itself, see
+[Overview of Carina]({{ site.baseurl }}docs/overview-of-carina/).
+To begin using Carina, see
+[Getting started on Carina]({{ site.baseurl }}/docs/getting-started/getting-started-on-carina/).
 
 ### About the author
 

--- a/_ecosystem/2015-10-16-container-technologies-scheduling-management.md
+++ b/_ecosystem/2015-10-16-container-technologies-scheduling-management.md
@@ -180,14 +180,12 @@ Other recommended reading:
 
 - <https://www.linux.com/learn/tutorials/788613-understanding-and-using-systemd>
 
-In addition to *best-practices* articles such as this one,
-Carina documentation includes *getting started* guidance and *tutorials*:
-
-* For information about Carina by Rackspace and getting started
-  with clusters and containers, explore the *​getting started​* collection.
-* For step-by-step demonstrations and instructions, explore the *tutorials* collection.
-* For discussions of key ideas, recommendations of useful methods and tools, and
-  general good advice, explore the *best-practices* collection.
+The purpose of this article is to help you understand Carina by introducing you
+to the ecosystem of container-related tools.
+To begin learning about Carina itself, see
+[Overview of Carina]({{ site.baseurl }}docs/overview-of-carina/).
+To begin using Carina, see
+[Getting started on Carina]({{ site.baseurl }}/docs/getting-started/getting-started-on-carina/).
 
 ### About the author
 

--- a/_ecosystem/2015-10-17-container-technologies-registration-discover.md
+++ b/_ecosystem/2015-10-17-container-technologies-registration-discover.md
@@ -163,14 +163,12 @@ Other recommended reading:
 
 - <http://www.infoq.com/articles/cap-twelve-years-later-how-the-rules-have-changed>
 
-In addition to *best-practices* articles such as this one,
-Carina documentation includes *getting started* guidance and *tutorials*:
-
-* For information about Carina by Rackspace and getting started
-  with clusters and containers, explore the *​getting started​* collection.
-* For step-by-step demonstrations and instructions, explore the *tutorials* collection.
-* For discussions of key ideas, recommendations of useful methods and tools, and
-  general good advice, explore the *best-practices* collection.
+The purpose of this article is to help you understand Carina by introducing you
+to the ecosystem of container-related tools.
+To begin learning about Carina itself, see
+[Overview of Carina]({{ site.baseurl }}docs/overview-of-carina/).
+To begin using Carina, see
+[Getting started on Carina]({{ site.baseurl }}/docs/getting-started/getting-started-on-carina/).
 
 ### About the author
 

--- a/_ecosystem/2015-10-18-container-technologies-orchestration-clusters.md
+++ b/_ecosystem/2015-10-18-container-technologies-orchestration-clusters.md
@@ -580,14 +580,12 @@ Other recommended reading:
 
 - <https://github.com/mesosphere/deimos>
 
-In addition to *best-practices* articles such as this one,
-Carina documentation includes *getting started* guidance and *tutorials*:
-
-* For information about Carina by Rackspace and getting started
-  with clusters and containers, explore the *​getting started​* collection.
-* For step-by-step demonstrations and instructions, explore the *tutorials* collection.
-* For discussions of key ideas, recommendations of useful methods and tools, and
-  general good advice, explore the *best-practices* collection.
+The purpose of this article is to help you understand Carina by introducing you
+to the ecosystem of container-related tools.
+To begin learning about Carina itself, see
+[Overview of Carina]({{ site.baseurl }}docs/overview-of-carina/).
+To begin using Carina, see
+[Getting started on Carina]({{ site.baseurl }}/docs/getting-started/getting-started-on-carina/).
 
 ### About the author
 

--- a/_ecosystem/2015-10-19-container-technologies-operating-systems.md
+++ b/_ecosystem/2015-10-19-container-technologies-operating-systems.md
@@ -79,14 +79,12 @@ Other recommended reading:
 
 - [Introduction to container technologies: scheduling and management of services and resources]({{ site.baseurl }}/docs/best-practices/container-technologies-scheduling-management/)
 
-In addition to *best-practices* articles such as this one,
-Carina documentation includes *getting started* guidance and *tutorials*:
-
-* For information about Carina by Rackspace and getting started
-  with clusters and containers, explore the *​getting started​* collection.
-* For step-by-step demonstrations and instructions, explore the *tutorials* collection.
-* For discussions of key ideas, recommendations of useful methods and tools, and
-  general good advice, explore the *best-practices* collection.
+The purpose of this article is to help you understand Carina by introducing you
+to the ecosystem of container-related tools.
+To begin learning about Carina itself, see
+[Overview of Carina]({{ site.baseurl }}docs/overview-of-carina/).
+To begin using Carina, see
+[Getting started on Carina]({{ site.baseurl }}/docs/getting-started/getting-started-on-carina/).
 
 ### About the author
 

--- a/_ecosystem/2015-10-20-container-technologies-networking.md
+++ b/_ecosystem/2015-10-20-container-technologies-networking.md
@@ -151,14 +151,12 @@ Other recommended reading:
 
 - <https://github.com/socketplane/socketplane/blob/master/README.md>
 
-In addition to *best-practices* articles such as this one,
-Carina documentation includes *getting started* guidance and *tutorials*:
-
-* For information about Carina by Rackspace and getting started
-  with clusters and containers, explore the *​getting started​* collection.
-* For step-by-step demonstrations and instructions, explore the *tutorials* collection.
-* For discussions of key ideas, recommendations of useful methods and tools, and
-  general good advice, explore the *best-practices* collection.
+The purpose of this article is to help you understand Carina by introducing you
+to the ecosystem of container-related tools.
+To begin learning about Carina itself, see
+[Overview of Carina]({{ site.baseurl }}docs/overview-of-carina/).
+To begin using Carina, see
+[Getting started on Carina]({{ site.baseurl }}/docs/getting-started/getting-started-on-carina/).
 
 ### About the author
 

--- a/_ecosystem/2015-10-21-container-technologies-market-analysis.md
+++ b/_ecosystem/2015-10-21-container-technologies-market-analysis.md
@@ -176,14 +176,12 @@ Other recommended reading:
 
 - [Docker's documentation](http://docs.docker.com/)
 
-In addition to *best-practices* articles such as this one,
-Carina documentation includes *getting started* guidance and *tutorials*:
-
-* For information about Carina by Rackspace and getting started
-  with clusters and containers, explore the *​getting started​* collection.
-* For step-by-step demonstrations and instructions, explore the *tutorials* collection.
-* For discussions of key ideas, recommendations of useful methods and tools, and
-  general good advice, explore the *best-practices* collection.
+The purpose of this article is to help you understand Carina by introducing you
+to the ecosystem of container-related tools.
+To begin learning about Carina itself, see
+[Overview of Carina]({{ site.baseurl }}docs/overview-of-carina/).
+To begin using Carina, see
+[Getting started on Carina]({{ site.baseurl }}/docs/getting-started/getting-started-on-carina/).
 
 ### About the author
 

--- a/_ecosystem/2015-10-22-container-technologies-docker.md
+++ b/_ecosystem/2015-10-22-container-technologies-docker.md
@@ -204,14 +204,12 @@ Other recommended reading:
 
 - [Docker best practices: image repository]({{ site.baseurl }}/docs/best-practices/docker-best-practices-image-repository/)
 
-In addition to *best-practices* articles such as this one,
-Carina documentation includes *getting started* guidance and *tutorials*:
-
-* For information about Carina by Rackspace and getting started
-  with clusters and containers, explore the *​getting started​* collection.
-* For step-by-step demonstrations and instructions, explore the *tutorials* collection.
-* For discussions of key ideas, recommendations of useful methods and tools, and
-  general good advice, explore the *best-practices* collection.
+The purpose of this article is to help you understand Carina by introducing you
+to the ecosystem of container-related tools.
+To begin learning about Carina itself, see
+[Overview of Carina]({{ site.baseurl }}docs/overview-of-carina/).
+To begin using Carina, see
+[Getting started on Carina]({{ site.baseurl }}/docs/getting-started/getting-started-on-carina/).
 
 ### About the author
 

--- a/_ecosystem/2015-10-23-container-ecosystem-openshift.md
+++ b/_ecosystem/2015-10-23-container-ecosystem-openshift.md
@@ -86,14 +86,12 @@ Other recommended reading:
 
 - [Introduction to container technologies: orchestration and management of container clusters]({{ site.baseurl }}/docs/best-practices/container-technologies-orchestration-clusters/)
 
-In addition to *best-practices* articles such as this one,
-Carina documentation includes *getting started* guidance and *tutorials*:
-
-* For information about Carina by Rackspace and getting started
-  with clusters and containers, explore the *​getting started​* collection.
-* For step-by-step demonstrations and instructions, explore the *tutorials* collection.
-* For discussions of key ideas, recommendations of useful methods and tools, and
-  general good advice, explore the *best-practices* collection.
+The purpose of this article is to help you understand Carina by introducing you
+to the ecosystem of container-related tools.
+To begin learning about Carina itself, see
+[Overview of Carina]({{ site.baseurl }}docs/overview-of-carina/).
+To begin using Carina, see
+[Getting started on Carina]({{ site.baseurl }}/docs/getting-started/getting-started-on-carina/).
 
 ### About the author
 

--- a/_ecosystem/2015-10-24-container-ecosystem-mesos-openstack.md
+++ b/_ecosystem/2015-10-24-container-ecosystem-mesos-openstack.md
@@ -92,14 +92,12 @@ Other recommended reading
 
 - <https://wiki.openstack.org/wiki/Magnum>
 
-In addition to *best-practices* articles such as this one,
-Carina documentation includes *getting started* guidance and *tutorials*:
-
-* For information about Carina by Rackspace and getting started
-  with clusters and containers, explore the *​getting started​* collection.
-* For step-by-step demonstrations and instructions, explore the *tutorials* collection.
-* For discussions of key ideas, recommendations of useful methods and tools, and
-  general good advice, explore the *best-practices* collection.
+The purpose of this article is to help you understand Carina by introducing you
+to the ecosystem of container-related tools.
+To begin learning about Carina itself, see
+[Overview of Carina]({{ site.baseurl }}docs/overview-of-carina/).
+To begin using Carina, see
+[Getting started on Carina]({{ site.baseurl }}/docs/getting-started/getting-started-on-carina/).
 
 ### About the author
 

--- a/_ecosystem/2015-10-25-container-ecosystem-kubernetes.md
+++ b/_ecosystem/2015-10-25-container-ecosystem-kubernetes.md
@@ -210,14 +210,12 @@ Other recommended reading:
 
 - [RFC1918 Address Allocation for Private Internets](https://tools.ietf.org/html/rfc1918)
 
-In addition to *best-practices* articles such as this one,
-Carina documentation includes *getting started* guidance and *tutorials*:
-
-* For information about Carina by Rackspace and getting started
-  with clusters and containers, explore the *​getting started​* collection.
-* For step-by-step demonstrations and instructions, explore the *tutorials* collection.
-* For discussions of key ideas, recommendations of useful methods and tools, and
-  general good advice, explore the *best-practices* collection.
+The purpose of this article is to help you understand Carina by introducing you
+to the ecosystem of container-related tools.
+To begin learning about Carina itself, see
+[Overview of Carina]({{ site.baseurl }}docs/overview-of-carina/).
+To begin using Carina, see
+[Getting started on Carina]({{ site.baseurl }}/docs/getting-started/getting-started-on-carina/).
 
 ### About the author
 

--- a/_ecosystem/2015-10-26-container-design-philosophy.md
+++ b/_ecosystem/2015-10-26-container-design-philosophy.md
@@ -77,14 +77,12 @@ Other recommended reading:
 
 - <http://www.forbes.com/sites/alexkonrad/2015/07/01/meet-docker-founder-solomon-hykes/>
 
-In addition to *best-practices* articles such as this one,
-Carina documentation includes *getting started* guidance and *tutorials*:
-
-* For information about Carina by Rackspace and getting started
-  with clusters and containers, explore the *​getting started​* collection.
-* For step-by-step demonstrations and instructions, explore the *tutorials* collection.
-* For discussions of key ideas, recommendations of useful methods and tools, and
-  general good advice, explore the *best-practices* collection.
+The purpose of this article is to help you understand Carina by introducing you
+to the ecosystem of container-related tools.
+To begin learning about Carina itself, see
+[Overview of Carina]({{ site.baseurl }}docs/overview-of-carina/).
+To begin using Carina, see
+[Getting started on Carina]({{ site.baseurl }}/docs/getting-started/getting-started-on-carina/).
 
 ### About the author
 


### PR DESCRIPTION
@kmsholcomb & @stephamon, all the articles that were in /_best-practices/ and are now in /_ecosystem/ conclude with the same suggestion to go read the Carina doc rather than stopping with this background information. The Carina doc is re-reorganized (now grouped into Getting Started, Concepts, Troubleshooting, Reference, Container Ecosystem) in a way that doesn't match the suggestion text, and there now seems to be a clear starting point among the Getting Started articles, so I want to streamline that suggestion in all Container Ecosystem articles to point to one Getting Started article. 

In this PR, I've rewritten it for 1 article. After you help get it as good as it can be, I'll make the same change in all the other Container Ecosystem articles. 

(Markdown doesn't have have same same include mechanism as RST, so we can't do what we just did in https://github.com/rackerlabs/docs-quickstart/pull/60, changing the text once for use in multiple articles.)