### PR TITLE
Add ToC to FAQs and Glossary. Fixes #615.

### DIFF
--- a/_reference/2015-10-18-faq.md
+++ b/_reference/2015-10-18-faq.md
@@ -8,110 +8,112 @@ topics:
   - troubleshooting
   - docker
   - Carina
+faqs:
+  -
+    question: I am an existing Rackspace customer. Can I use Carina with my existing account? Why won't my Rackspace account work?
+    answer: |
+      You can use your existing Rackspace account username (the same you use for the Cloud Control Panel) to sign into Carina. The Beta will also be free to you, just like everyone else. Please note, however, that **we don't support two-factor authentication at the moment**. To work around this, you can [create a sub-user](https://community.rackspace.com/products/f/54/t/4551).
+  -
+    question: I've got some feedback or questions. Where can I go for this?
+    answer: |
+      During the Beta period Carina is supported through [community forums](https://community.getcarina.com/) and [IRC at #carina on Freenode](http://webchat.freenode.net/?channels=carina).
+  -
+    question: I've found a bug. Where can I go to report it?
+    answer: |
+      We're happy to receive bug reports from you. All bugs related to Carina in general (CLI, UI, docs, back end) should be issued to [github.com/getcarina/feedback](https://github.com/getcarina/feedback/issues). If the bug is security related, refer to our [Security Vulnerability Reporting guidelines](http://www.rackspace.com/information/legal/rsdp/).
+  -
+    question: Can I use Carina for production workloads?
+    answer: |
+      We're still working hard to add new features to Carina. As a result, there may be some changes we have to make to the environment. Most changes won't impact your running clusters containers. When we move into production there will likely be major interuptions, but we will give you plenty of warning and guidance. Please treat Carina as an experimental Beta; we'll be doing our best to ensure uptime, but ultimately won't be able to guarantee it. One thing you can do to ensure that your application stays up is to start your containers with the `--restart always` option, which ensures they restart after segment or host restart.
+  -
+    question: What happens when a new version of Docker is released?
+    answer: |
+      When a new version of Docker is released, we'll test it in our environment. After testing, we'll make it available in Carina, at which point any new cluster build will use the newer version. **Running clusters won't be upgraded by default**, so you will have to redeploy your application into a new cluster to take advantage of the newer version.
+  -
+    question: My <code>-v /segment-dir:/container-dir</code> option doesn't seem to work. Why?
+    answer: |
+      Carina uses AppArmor to provide additional security to the environment. This means you'll only be allowed to bind-mount from the `/var/lib/docker` segment directory. As a result any `-v` directive should looks like this: `-v /var/lib/docker:/container-dir`.
+  -
+    question: I am having trouble running my container. What can I do?
+    answer: |
+      We've published a tutorial to [troubleshoot common problems]({{ site.baseurl }}/docs/troubleshooting/common-problems/). If you continue to have problems, use our [forums and ask our community](https://community.getcarina.com).
+
+  -
+    question: How does autoscaling work in Carina?
+    answer: |
+      Carina currently offers simple scale-up capabilities. For details, see the [Autoscaling resources in Carina ]({{ site.baseurl }}/docs/reference/autoscaling-carina/) tutorial.
+
+  -
+    question: What does the cluster rebuild action do?
+    answer: |
+      As explained in the ["how" section of the overview article]({{ site.baseurl }}/docs/overview-of-carina/#how-does-carina-work), Carina currently relies on Swarm to manage the placement of containers. Swarm relies on management containers. If you accidentally delete these containers, your Swarm cluster won't work properly anymore. If this happens, you can use the rebuild action to re-initialize the Swarm cluster. Rebuilding will interrupt or kill your interactive container session; however, daemonized containers will continue running and remain untouched.
+  -
+    question: What resources does a single cluster have?
+    answer: |
+      All cluster segments currently have 4 GB of memory and roughly the equivalent of two vCPUs. As a result, a single **Docker container can never grow larger than 4 GB of memory**. Clusters currently have a maximum of three segments for a total of six vCPUs and 16 GB or memory. By default, you can create a maximum of three clusters. If you have a use case that requires more resources, [please contact us](https://community.getcarina.com/t/capacity-requests/22/1). After the Beta these parameters will be configurable, but we're currently limiting them to accommodate everyone.
+
+  -
+    question: Can I get access to the underlying segment?
+    answer: |
+      Direct access to the underlying segment (LXC container) won't be given to users. Carina is a managed container service; we run the infrastructure so you can focus on running your application.
+  -
+    question: Why can't my containers talk to each other?
+    answer: |
+      Containers on the same segment should simply be "linked" together. To find out more, see [Connect containers with Docker links]({{ site.baseurl }}/docs/tutorials/connect-docker-containers-with-links/#connect-two-containers-with-a-docker-link). If your containers live on different segments you'll have to rely on the [ambassador pattern]({{ site.baseurl }}/docs/tutorials/connect-docker-containers-ambassador-pattern/#connect-containers).
+  -
+    question: When will Carina come out of Beta?
+    answer: |
+      We're not rushing to put Carina into production. We'd like to collect feedback and add more features as well as orchestration engines. When we have more detail on production readiness dates, we'll let you know.
+  -
+    question: How long will Carina be free? When you start charging, what will it cost?
+    answer: |
+      While Carina won't be free forever, we will continue to keep a free tier, even after we start charging. As soon as we have pricing details, we will make them public, so you can educate yourself long before we start charging. You'll be positively surprised.
+  -
+    question: When I run `docker info` against my cluster, there are already containers running there. Why?
+    answer: |
+      Docker Swarm requires an agent and manager to work. They currently run on cluster segments in the form of containers. Although only one manager is required per cluster, we've configured it to run on all segments in the cluster to add some redundancy and make communicating with the cluster easier. For more details, see the ["how" section of the overview article]({{ site.baseurl }}/docs/overview-of-carina/#how-does-carina-work).
+  -
+    question: Is there an API for all this?
+    answer: |
+      Yes, we have an API, but it will change before we move into production. If you want to use it, start by using the CLI tool's code base. See [Getting Started with the Carina CLI]({{ site.baseurl }}/docs/getting-started/getting-started-carina-cli/#download-and-install-carina-cli).
+  -
+    question: How are you currently preventing containers running in <code>--privileged</code> mode?
+    answer: |
+      AppArmor profiles at the compute host level deny certain capabilities and permissions that Docker needs for <code>--privileged</code>. When Docker tries to spawn a privileged container, AppArmor denies it. For more details, see [Understanding how Carina uses Docker Swarm]({{ site.baseurl }}/docs/concepts/docker-swarm-carina/#apparmor-profiles).
+  -
+    question: What level of control do I get over segment networking? How do I allocate IP addresses?
+    answer: |
+      Currently Carina controls all the networking for you. Every segment is allocated a public IPv4 address, which makes connectivity easy, but should be considered when you are deploying Docker containers that expose services publicly.
+  -
+    question: Can I get access to the TLS certificates?
+    answer: |
+      All of the certificates necessary to talk to the Docker daemon or Swarm manager are on each segment. You can access them by using `--volumes-from swarm-data:ro`. You'll find them in `/etc/docker`. We don't have the local UNIX socket, but you can easily talk over a TCP socket with `--net=host`. These run arguments should set everything up.
+
+      Talk to Swarm:
+
+      ```
+      --net=host --volumes-from swarm-data:ro -e DOCKER_HOST=tcp://127.0.0.1:2376 -e DOCKER_CERT_PATH​=/etc/docker -e DOCKER_TLS_VERIFY=1
+      ```
+
+      Talk to the local daemon:
+
+      ```
+      --net=host --volumes-from swarm-data:ro -e DOCKER_HOST=tcp://127.0.0.1:42376 -e DOCKER_CERT_PATH​=/etc/docker -e DOCKER_TLS_VERIFY=1​
+      ```
 ---
 
-#### I am an existing Rackspace customer. Can I use Carina with my existing account? Why won't my Rackspace account work?
+<div class="table-of-contents">
+  <h4>Contents</h4>
+  <ul>
+  {% for faq in page.faqs %}
+    <li><a href="#{{ faq.question | slugify }}">{{ faq.question }}</a></li>
+  {% endfor %}
+  </ul>
+</div>
 
-You can use your existing Rackspace account username (the same you use for the Cloud Control Panel) to sign into Carina. The Beta will also be free to you, just like everyone else. Please note, however, that **we don't support two-factor authentication at the moment**. To work around this, you can [create a sub-user](https://community.rackspace.com/products/f/54/t/4551).
-
-
-#### I've got some feedback or questions. Where can I go for this?
-
-During the Beta period Carina is supported through [community forums](https://community.getcarina.com/) and [IRC at #carina on Freenode](http://webchat.freenode.net/?channels=carina).
-
-
-#### I've found a bug. Where can I go to report it?
-
-We're happy to receive bug reports from you. All bugs related to Carina in general (CLI, UI, docs, back end) should be issued to [github.com/getcarina/feedback](https://github.com/getcarina/feedback/issues). If the bug is security related, refer to our [Security Vulnerability Reporting guidelines](http://www.rackspace.com/information/legal/rsdp/).
-
-
-#### Can I use Carina for production workloads?
-
-We're still working hard to add new features to Carina. As a result, there may be some changes we have to make to the environment. Most changes won't impact your running clusters containers. When we move into production there will likely be major interuptions, but we will give you plenty of warning and guidance. Please treat Carina as an experimental Beta; we'll be doing our best to ensure uptime, but ultimately won't be able to guarantee it. One thing you can do to ensure that your application stays up is to start your containers with the `--restart always` option, which ensures they restart after segment or host restart.
-
-
-#### What happens when a new version of Docker is released?
-
-When a new version of Docker is released, we'll test it in our environment. After testing, we'll make it available in Carina, at which point any new cluster build will use the newer version. **Running clusters won't be upgraded by default**, so you will have to redeploy your application into a new cluster to take advantage of the newer version.
-
-
-#### My <code>-v /segment-dir:/container-dir</code> option doesn't seem to work. Why?
-
-Carina uses AppArmor to provide additional security to the environment. This means you'll only be allowed to bind-mount from the `/var/lib/docker` segment directory. As a result any `-v` directive should looks like this: `-v /var/lib/docker:/container-dir`.
-
-
-#### I am having trouble running my container. What can I do?
-
-We've published a tutorial to [troubleshoot common problems]({{ site.baseurl }}/docs/troubleshooting/common-problems/). If you continue to have problems, use our [forums and ask our community](https://community.getcarina.com).
-
-
-#### How does autoscaling work in Carina?
-
-Carina currently offers simple scale-up capabilities. For details, see the [Autoscaling resources in Carina ]({{ site.baseurl }}/docs/reference/autoscaling-carina/) tutorial.
-
-
-#### What does the cluster rebuild action do?
-
-As explained in the ["how" section of the overview article]({{ site.baseurl }}/docs/overview-of-carina/#how-does-carina-work), Carina currently relies on Swarm to manage the placement of containers. Swarm relies on management containers. If you accidentally delete these containers, your Swarm cluster won't work properly anymore. If this happens, you can use the rebuild action to re-initialize the Swarm cluster. Rebuilding will interrupt or kill your interactive container session; however, daemonized containers will continue running and remain untouched.
-
-
-#### What resources does a single cluster have?
-
-All cluster segments currently have 4 GB of memory and roughly the equivalent of two vCPUs. As a result, a single **Docker container can never grow larger than 4 GB of memory**. Clusters currently have a maximum of three segments for a total of six vCPUs and 16 GB or memory. By default, you can create a maximum of three clusters. If you have a use case that requires more resources, [please contact us](https://community.getcarina.com/t/capacity-requests/22/1). After the Beta these parameters will be configurable, but we're currently limiting them to accommodate everyone.
-
-
-#### Can I get access to the underlying segment?
-
-Direct access to the underlying segment (LXC container) won't be given to users. Carina is a managed container service; we run the infrastructure so you can focus on running your application.
-
-
-#### Why can't my containers talk to each other?
-
-Containers on the same segment should simply be "linked" together. To find out more, see [Connect containers with Docker links]({{ site.baseurl }}/docs/tutorials/connect-docker-containers-with-links/#connect-two-containers-with-a-docker-link). If your containers live on different segments you'll have to rely on the [ambassador pattern]({{ site.baseurl }}/docs/tutorials/connect-docker-containers-ambassador-pattern/#connect-containers).
-
-
-#### When will Carina come out of Beta?
-
-We're not rushing to put Carina into production. We'd like to collect feedback and add more features as well as orchestration engines. When we have more detail on production readiness dates, we'll let you know.
-
-
-#### How long will Carina be free? When you start charging, what will it cost?
-
-While Carina won't be free forever, we will continue to keep a free tier, even after we start charging. As soon as we have pricing details, we will make them public, so you can educate yourself long before we start charging. You'll be positively surprised.
-
-
-#### When I run `docker info` against my cluster, there are already containers running there. Why?
-
-Docker Swarm requires an agent and manager to work. They currently run on cluster segments in the form of containers. Although only one manager is required per cluster, we've configured it to run on all segments in the cluster to add some redundancy and make communicating with the cluster easier. For more details, see the ["how" section of the overview article]({{ site.baseurl }}/docs/overview-of-carina/#how-does-carina-work).
-
-
-#### Is there an API for all this?
-
-Yes, we have an API, but it will change before we move into production. If you want to use it, start by using the CLI tool's code base. See [Getting Started with the Carina CLI]({{ site.baseurl }}/docs/getting-started/getting-started-carina-cli/#download-and-install-carina-cli).
-
-
-####  How are you currently preventing containers running in <code>--privileged</code> mode?
-
-AppArmor profiles at the compute host level deny certain capabilities and permissions that Docker needs for <code>--privileged</code>. When Docker tries to spawn a privileged container, AppArmor denies it. For more details, see [Understanding how Carina uses Docker Swarm]({{ site.baseurl }}/docs/concepts/docker-swarm-carina/#apparmor-profiles).
-
-
-#### What level of control do I get over segment networking? How do I allocate IP addresses?
-
-Currently Carina controls all the networking for you. Every segment is allocated a public IPv4 address, which makes connectivity easy, but should be considered when you are deploying Docker containers that expose services publicly.
-
-
-#### Can I get access to the TLS certificates?
-
-All of the certificates necessary to talk to the Docker daemon or Swarm manager are on each segment. You can access them by using `--volumes-from swarm-data:ro`. You'll find them in `/etc/docker`. We don't have the local UNIX socket, but you can easily talk over a TCP socket with `--net=host`. These run arguments should set everything up.
-
-Talk to Swarm:
-
-```
---net=host --volumes-from swarm-data:ro -e DOCKER_HOST=tcp://127.0.0.1:2376 -e DOCKER_CERT_PATH​=/etc/docker -e DOCKER_TLS_VERIFY=1
-```
-
-Talk to the local daemon:
-
-```
---net=host --volumes-from swarm-data:ro -e DOCKER_HOST=tcp://127.0.0.1:42376 -e DOCKER_CERT_PATH​=/etc/docker -e DOCKER_TLS_VERIFY=1​
-```
+{% for faq in page.faqs %}
+  <h4 id="{{ faq.question | slugify }}">{{ faq.question }}</h4>
+  <div class="answer">
+    {{ faq.answer }}
+  </div>
+{% endfor %}

--- a/_reference/2015-10-19-glossary.md
+++ b/_reference/2015-10-19-glossary.md
@@ -7,138 +7,156 @@ description: Provides a glossary of the terms used in Carina documentation
 topics:
   - docker
   - containers
+terms:
+  -
+    term: Autoscaling
+    definition: |
+      A process that monitors your cluster resources and automatically grows a cluster if needed. A scaling action is triggered when either the average CPU or average memory consumption exceeds 80 percent across the cluster.
+  -
+    term: Ambassador pattern
+    definition: |
+      A pattern for linking containers. The ambassador pattern uses Docker links with specialized ambassador containers to enable communication between containers across Docker hosts.
+  -
+    term: AppArmor profile
+    definition: |
+      A security layer in Carina that keeps container resources isolated. AppArmor is a Linux kernel security module. The profile denies access to sensitive file paths on the hosts, whitelists expected mount calls for the container file system, and restricts the device capabilities of the Docker process.
+  -
+    term: Carina
+    definition: |
+      A hosted container runtime environment provided by Rackspace. Carina is built on the open-source Docker Swarm project and provides bare-metal speeds, security, and portability for running your applications in containers.
+  -
+    term: Carina CLI
+    definition: |
+      A command-line interface for Carina that you can use to launch and control Docker Swarm clusters on a Carina endpoint.
+  -
+    term: Cluster
+    definition: |
+      A pool of compute, storage, and networking resources that serves as a host for one or more containerized applications. Carina provisions Docker Swarm clusters for running containers.
+  -
+    term: Container
+    definition: |
+      A userspace instance that packages a piece of software with a complete file system that contains everything that the software needs to run, such as code, system tools, and system libraries. Each container is an isolated and secure application platform. A container is created from an *image*. Containers can be run, started, stopped, moved, and deleted.
+  -
+    term: Control plane
+    definition: |
+      The component of Carina that takes the commands that you input in the UI or CLI and performs functions such as creating clusters and adding segments to clusters.
+  -
+    term: Credentials
+    definition: |
+      A set of TLS certificates and environment configuration files that you need to download and use to authenticate to your Carina cluster.
+  -
+    term: Data volume
+    definition: |
+      A directory within a container that stores data and is meant to persist beyond the life cycle of the container. Data volumes can be shared and reused among containers, and they can be created in special *data volume containers*.
+  -
+    term: Data volume container (DVC)
+    definition: |
+      A container that houses one or more volumes and whose sole aim is to store data in a persistent way. DVCs are often used as a centralized data store across multiple containers on the same Docker host. Other containers can mount the volume inside a DVC and save their data to it, providing non-persistent containers with a way to handle persistent storage.
+  -
+    term: Docker
+    definition: |
+      An open-source, client-server platform for building, shipping, and running distributed applications in containers. Also referred to as the Docker Engine.
+  -
+    term: Docker client
+    definition: |
+      The primary user interface to Docker. The client accepts commands from users and communicates with the Docker *daemon*, which runs in the Docker host. In Carina, the client is configured to communicate with the segments in a cluster.
+  -
+    term: Docker Compose
+    definition: |
+      A tool used to define and run multicontainer applications with Docker. With Compose, you use a YAML file to define a multicontainer application, and then start the application with a single command.
+  -
+    term: Docker daemon
+    definition: |
+      Runs in a Docker host and builds, runs, and distributes containers. Users interact with the daemon through the Docker *client*. Sometimes referred to as the Docker *server* or *engine*.  	
+  -
+    term: Docker host
+    definition: |
+      A machine that runs the *Docker daemon*. The host is also where images are built and containers are created. When Docker is run locally on Windows and Mac OS X machines, the host runs in a virtual machine built by the *Docker Machine*. In Carina clusters, the equivalent of a Docker host is a *segment*.
+  -
+    term: Docker Hub
+    definition: |
+      The public Docker *registry* from which you can upload or download images.
+  -
+    term: Docker image
+    definition: |
+      A read-only template that is used to create Docker containers. For example, an image could contain an Ubuntu operating system with Apache and your web application installed. You can download public images or create your own. Images are stored in *registries*.   	
+  -
+    term: Docker links
+    definition: |
+      A Docker configuration option that connects containers. Links enable containers that are on the same host to communicate.
+  -
+    term: Docker Machine
+    definition: |
+      Software that enables you to create Docker hosts on your computer or in the cloud. It creates hosts, installs Docker on them, and configures the Docker client to talk to them. A machine is the combination of a Docker *host* and a Docker *client*. Docker Machine uses the `docker-machine` binary.  	
+  -
+    term: Docker Swarm
+    definition: |
+      A clustering tool for Docker. Swarm enables you to host and schedule a cluster of Docker containers. Carina uses Docker Swarm clusters.
+  -
+    term: Docker Toolbox
+    definition: |
+      Installs and sets up a Docker environment on a computer. Toolbox is available for Windows and Mac OS X, and it installs the Docker client, Docker Machine, Docker Compose (Mac only), Kitematic, and Oracle VM VirtualBox.
+  -
+    term: Dockerfile
+    definition: |
+      A text document that contains all of the commands that a user would call on the command line to assemble an *image*.
+  -
+    term: dvm
+    definition: |
+      Docker Version Manager. A cross-platform command-line tool that you can use to install and switch between Docker clients. Using dvm avoids and addresses the Docker client/server API mismatch error. Carina's credentials are designed to work with dvm. After you load your cluster credentials, run `dvm use`, and dvm will switch to the version of Docker used by your cluster.   
+  -
+    term: Microservices
+    definition: |
+      A software architecture style in which complex applications comprise small, independent processes that communicate with each other through APIs.
+  -
+    term: PublicNet
+    definition: |
+      A public network interface that connects Carina segments to the public Internet. When you create a segment, it gets an IPv4 and IPv6 address from PublicNet by default. This is the address that the segment uses to communicate with the public Internet.
+  -
+    term: Registry
+    definition: |
+      An open-source service application that stores and distributes Docker images. You can run your own registry or use one of the publicly available registries. The public Docker registry is called *Docker Hub*.
+  -
+    term: Segment
+    definition: |
+      A portion of the resources available in a cluster. Containers are housed in segments on the cluster. A Carina segment is an LXC container provisioned by libvirt. Segments are composed of a Swarm agent, a Docker Engine, and containers.
+  -
+    term: Service discovery
+    definition: |
+      The process of discovering what services are available for an application. Service discovery is a two-part process. *Registration* is the process of a service registering its location with a central directory. *Discovery* occurs when a client application asks the directory for the location of a service.
+  -
+    term: ServiceNet
+    definition: |
+      An internal, multi-tenant network interface that connects segments within Carina. When you create a segment, it gets only an IPv4 address from ServiceNet by default. This is the address that the segment can use to communicate with other segments in Carina.
+  -
+    term: Scheduler
+    definition: |
+      A mechanism that is responsible for the life cycle of a container. The scheduler chooses the best *segment* to put the container in, and starts, stops, and destroys the container when requested. Different scheduler strategies can be used to pick the best segment to hold a container. In Carina, the spread scheduler strategy is used.
+  -
+    term: Swarm agent
+    definition: |
+      The component on a segment that accepts commands from the *Swarm manager*. The agent communicates with the Docker Engine to perform the commands, such as running containers.
+  -
+    term: Swarm manager
+    definition: |
+      The component that orchestrates and schedules containers across an entire cluster. The Swarm manager assigns your containers to the segments in the cluster via the *Swarm agent*.
+
 ---
 
-The following terms are used in the documentation for Carina.
-
-##### autoscaling
-
-A process that monitors your cluster resources and automatically grows a cluster if needed. A scaling action is triggered when either the average CPU or average memory consumption exceeds 80 percent across the cluster.
-
-##### ambassador pattern
-
-A pattern for linking containers. The ambassador pattern uses Docker links with specialized ambassador containers to enable communication between containers across Docker hosts.
-
-##### AppArmor profile
-
-A security layer in Carina that keeps container resources isolated. AppArmor is a Linux kernel security module. The profile denies access to sensitive file paths on the hosts, whitelists expected mount calls for the container file system, and restricts the device capabilities of the Docker process.
-
-##### Carina
-
-A hosted container runtime environment provided by Rackspace. Carina is built on the open-source Docker Swarm project and provides bare-metal speeds, security, and portability for running your applications in containers.
-
-##### Carina CLI
-
-A command-line interface for Carina that you can use to launch and control Docker Swarm clusters on a Carina endpoint.
-
-##### cluster
-
-A pool of compute, storage, and networking resources that serves as a host for one or more containerized applications. Carina provisions Docker Swarm clusters for running containers.
-
-##### container
-
-A userspace instance that packages a piece of software with a complete file system that contains everything that the software needs to run, such as code, system tools, and system libraries. Each container is an isolated and secure application platform. A container is created from an *image*. Containers can be run, started, stopped, moved, and deleted.
-
-##### control plane
-
-The component of Carina that takes the commands that you input in the UI or CLI and performs functions such as creating clusters and adding segments to clusters.
-
-##### credentials
-
-A set of TLS certificates and environment configuration files that you need to download and use to authenticate to your Carina cluster.
-
-##### data volume
-
-A directory within a container that stores data and is meant to persist beyond the life cycle of the container. Data volumes can be shared and reused among containers, and they can be created in special *data volume containers*.
-
-##### data volume container (DVC)
-
-A container that houses one or more volumes and whose sole aim is to store data in a persistent way. DVCs are often used as a centralized data store across multiple containers on the same Docker host. Other containers can mount the volume inside a DVC and save their data to it, providing non-persistent containers with a way to handle persistent storage.
-
-##### Docker
-
-An open-source, client-server platform for building, shipping, and running distributed applications in containers. Also referred to as the Docker Engine.
-
-##### Docker client
-
-The primary user interface to Docker. The client accepts commands from users and communicates with the Docker *daemon*, which runs in the Docker host. In Carina, the client is configured to communicate with the segments in a cluster.
-
-##### Docker Compose
-
-A tool used to define and run multicontainer applications with Docker. With Compose, you use a YAML file to define a multicontainer application, and then start the application with a single command.
-
-##### Docker daemon
-
-Runs in a Docker host and builds, runs, and distributes containers. Users interact with the daemon through the Docker *client*. Sometimes referred to as the Docker *server* or *engine*.  	
-
-##### Docker host
-
-A machine that runs the *Docker daemon*. The host is also where images are built and containers are created. When Docker is run locally on Windows and Mac OS X machines, the host runs in a virtual machine built by the *Docker Machine*. In Carina clusters, the equivalent of a Docker host is a *segment*.
-
-##### Docker Hub
-
-The public Docker *registry* from which you can upload or download images.
-
-##### Docker image
-
-A read-only template that is used to create Docker containers. For example, an image could contain an Ubuntu operating system with Apache and your web application installed. You can download public images or create your own. Images are stored in *registries*.   	
-
-##### Docker links
-
-A Docker configuration option that connects containers. Links enable containers that are on the same host to communicate.
-
-##### Docker Machine
-
-Software that enables you to create Docker hosts on your computer or in the cloud. It creates hosts, installs Docker on them, and configures the Docker client to talk to them. A machine is the combination of a Docker *host* and a Docker *client*. Docker Machine uses the `docker-machine` binary.  	
-
-##### Docker Swarm
-
-A clustering tool for Docker. Swarm enables you to host and schedule a cluster of Docker containers. Carina uses Docker Swarm clusters.
-
-##### Docker Toolbox
-
-Installs and sets up a Docker environment on a computer. Toolbox is available for Windows and Mac OS X, and it installs the Docker client, Docker Machine, Docker Compose (Mac only), Kitematic, and Oracle VM VirtualBox.
-
-##### Dockerfile
-
-A text document that contains all of the commands that a user would call on the command line to assemble an *image*.
-
-##### dvm
-
-Docker Version Manager. A cross-platform command-line tool that you can use to install and switch between Docker clients. Using dvm avoids and addresses the Docker client/server API mismatch error. Carina's credentials are designed to work with dvm. After you load your cluster credentials, run `dvm use`, and dvm will switch to the version of Docker used by your cluster.   
-
-##### microservices
-
-A software architecture style in which complex applications comprise small, independent processes that communicate with each other through APIs.
-
-##### PublicNet
-
-A public network interface that connects Carina segments to the public Internet. When you create a segment, it gets an IPv4 and IPv6 address from PublicNet by default. This is the address that the segment uses to communicate with the public Internet.
-
-##### registry
-
-An open-source service application that stores and distributes Docker images. You can run your own registry or use one of the publicly available registries. The public Docker registry is called *Docker Hub*.
-
-##### segment
-
-A portion of the resources available in a cluster. Containers are housed in segments on the cluster. A Carina segment is an LXC container provisioned by libvirt. Segments are composed of a Swarm agent, a Docker Engine, and containers.
-
-##### service discovery
-
-The process of discovering what services are available for an application. Service discovery is a two-part process. *Registration* is the process of a service registering its location with a central directory. *Discovery* occurs when a client application asks the directory for the location of a service.
-
-##### ServiceNet
-
-An internal, multi-tenant network interface that connects segments within Carina. When you create a segment, it gets only an IPv4 address from ServiceNet by default. This is the address that the segment can use to communicate with other segments in Carina.
-
-##### scheduler
-
-A mechanism that is responsible for the life cycle of a container. The scheduler chooses the best *segment* to put the container in, and starts, stops, and destroys the container when requested. Different scheduler strategies can be used to pick the best segment to hold a container. In Carina, the spread scheduler strategy is used.
-
-##### Swarm agent
-
-The component on a segment that accepts commands from the *Swarm manager*. The agent communicates with the Docker Engine to perform the commands, such as running containers.
-
-##### Swarm manager
-
-The component that orchestrates and schedules containers across an entire cluster. The Swarm manager assigns your containers to the segments in the cluster via the *Swarm agent*.
+<div class="table-of-contents">
+  <h4>Contents</h4>
+  <ul>
+  {% for term in page.terms %}
+    <li><a href="#{{ term.term | slugify }}">{{ term.term }}</a></li>
+  {% endfor %}
+  </ul>
+</div>
+
+The following terms are used in the documentation for Carina:
+
+{% for term in page.terms %}
+  <h4 id="{{ term.term | slugify }}">{{ term.term }}</h4>
+  <div class="definition">
+    {{ term.definition }}
+  </div>
+{% endfor %}


### PR DESCRIPTION
Puts FAQs and Glossary into the frontmatter of their respective pages as an array of dictionaries. This lets us loop over them and generally use them in more ways than one. We might consider moving these into a data file so they're accessible from other places on the site, too.