### PR TITLE
Troubleshooting swarm affinity and custom images

### DIFF
--- a/_troubleshooting/2015-09-21-troubleshooting.md
+++ b/_troubleshooting/2015-09-21-troubleshooting.md
@@ -2,6 +2,7 @@
 title: Troubleshooting common problems
 author: Everett Toews <everett.toews@rackspace.com>
 date: 2015-09-21
+featured: true
 permalink: docs/troubleshooting/common-problems/
 description: Troubleshooting common problems on Carina
 docker-versions:

--- a/_troubleshooting/2016-02-09-troubleshooting-swarm-affinity.md
+++ b/_troubleshooting/2016-02-09-troubleshooting-swarm-affinity.md
@@ -1,0 +1,203 @@
+---
+title: Error running a container using a custom image
+author: Carolyn Van Slyck <carolyn.vanslyck@rackspace.com>
+date: 2016-02-09
+permalink: docs/troubleshooting/troubleshooting-swarm-affinity/
+description: Troubleshoot the "image is not found" error when running a container
+docker-versions:
+  - 1.9.1
+topics:
+  - docker
+  - swarm
+  - troubleshooting
+---
+
+When you try to run a Docker container using a custom image that you have built,
+as shown in the following example, it does not start and the following error
+message is displayed:
+
+```
+$ docker build --tag <custom-image> .
+Successfully built abf38d5a0750
+
+$ docker run --publish 50000:5000 <custom-image>
+0588fe5b93707d54b023b7e31f15bd4baa793201427819794d1dea6cbc7f9f70
+
+$ docker run --publish 5000:5000 <custom-image>
+Error response from daemon: Error: image library/<custom-image> not found
+```
+
+This error message indicates that the container was scheduled on a different segment
+than the segment that built the image, and therefore the image could not be found.
+To resolve this error, you must either
+[use Docker Swarm image affinity scheduling](#use-docker-swarm-image-affinity-scheduling),
+[use Docker Hub](#use-docker-hub), [use another public Docker registry](#use-a-public-docker-registry),
+or [use a private Docker registry](#use-a-private-docker-registry).
+
+**Note**: By default clusters contain only one segment, so you will only encounter
+this error when your cluster has two or more segments.
+
+### Use Docker Swarm image affinity scheduling
+Specify `--affinity:image==<custom-image>` when creating or running a container
+that uses `<custom-image>`. This instructs Docker Swarm to schedule the new
+container on a segment which has your custom image.
+
+```
+$ docker build -t <custom-image> .
+$ docker run --env affinity:image==<custom-image>
+```
+
+**Note**: If you need to run the container on multiple segments,
+then a Docker registry is required.
+
+<!-- In future versions of Docker Swarm the image affinity hint won't be necessary, because of
+https://github.com/docker/swarm/issues/743. However this article is still
+useful because if you need to run on multiple segments
+(not just the one the image was built upon) then you will need to use a registry -->
+
+### Use Docker Hub
+Docker Hub is the default, official Docker registry. Carina can discover images on
+[Docker Hub](https://hub.docker.com/), without requiring any configuration
+changes or command-line flags.
+
+1. Create a Docker Hub account.
+1. Log in to Docker Hub from the command line. Your credentials will be saved to `~/.docker/config.json`.
+
+    ```
+    $ docker login
+    Username: <dockerhub-user>
+    Password: <dockerhub-password>
+    Email: <dockerhub-email>
+    WARNING: login credentials saved in ~/.docker/config.json
+    Login Succeeded
+    ```
+
+1. Build your custom image. Ensure that `<custom-image>` follows the required
+    Docker Hub format of `<user>/<repo-name>:<tag>`, such as `myuser/myimage`.
+
+    ```
+    docker build --tag <custom-image> .
+    ```
+
+1. Push the custom image to Docker Hub.
+
+    ```
+    docker push <custom-image>
+    ```
+
+1. Run a docker container using the custom image.
+
+    ```
+    docker run <custom-image>
+    ```
+
+### Use a public Docker registry
+You can also use an alternative public Docker registry, such as [quay.io](http://quay.io),
+to host your custom image.
+
+1. Create an account on a public Docker registry.
+
+1. Log in to the registry from the command line. Your credentials will be saved to `~/.docker/config.json`.
+    Replace `<registry>` with the the registry's domain name, such as `quay.io`.
+
+
+    ```
+    $ docker login <registry>
+    Username: <registry-user>
+    Password: <registry-password>
+    Email: <registry-hub-email>
+    WARNING: login credentials saved in ~/.docker/config.json
+    Login Succeeded
+    ```
+
+1. Build your custom image. Ensure that `<custom-image>` follows the required
+    external registry format of `/<registry>/<user>/<repo-name>:<tag>`, such as `quay.io/myuser/myimage`.
+
+    ```
+    docker build --tag <custom-image> .
+    ```
+
+1. Push the custom image to the registry.
+
+    ```
+    docker push <custom-image>
+    ```
+
+    Docker uses the image name to determine
+    to which registry the image should be pushes. For example, if the image name
+    starts with `quay.io`, the image will be pushed to quay.io.
+
+1. Pull the custom image down to every segment in your cluster.
+
+    ```
+    docker pull <custom-image>
+    ```
+
+1. Run a docker container using the custom image.
+
+    ```
+    docker run <custom-image>
+    ```
+
+### Use a private Docker registry
+
+1. Follow the [Store private Docker registry images on Rackspace Cloud Files](https://getcarina.com/docs/tutorials/registry-on-cloud-files/)
+tutorial to set up a private Docker registry.
+
+1. Log in to the registry from the command line. Your credentials will be saved to `~/.docker/config.json`.
+    Replace `<registry-ip>:<registry-port>` with your private registry's IP address and port.
+
+
+    ```
+    $ docker login <registry-ip>:<registry-port>
+    Username: <registry-user>
+    Password: <registry-password>
+    Email: <registry-hub-email>
+    WARNING: login credentials saved in ~/.docker/config.json
+    Login Succeeded
+    ```
+
+    **Note**: You can configure a custom domain with your registry's IP address, and
+    run the registry service on port 80. Then you can simplify the login argument
+    `<regiery-ip>:<registry-port>` to `<custom-domain>`, such as `example.com`.
+
+1. Build your custom image. Ensure that `<custom-image>` follows the required
+    external registry format of `/<registry-ip>:<registry:port>/<repo-name>:<tag>`,
+    such as `172.99.73.114:5000/myimage`.
+
+    ```
+    docker build --tag <custom-image> .
+    ```
+
+    **Note**: If you configured a custom domain for your registry,
+    then you can simplify `<custom-image>` to
+    `<custom-domain>/<repo-name>:<tag>`, such as `example.com/myimage`.
+
+1. Push the custom image to the registry.
+
+    ```
+    docker push <custom-image>
+    ```
+
+    Docker uses the image name to determine
+    to which registry the image should be pushes. For example, if the image name
+    starts with `172.99.73.114:5000`, the image will be pushed to the private registry
+    located at that IP address and port.
+
+
+1. Pull the custom image down to every segment in your cluster.
+
+    ```
+    docker pull <custom-image>
+    ```
+
+1. Run a docker container using the custom image.
+
+    ```
+    docker run <custom-image>
+    ```
+
+### Resources
+
+* [Understanding how Carina uses Docker Swarm](https://getcarina.com/docs/concepts/docker-swarm-carina/)
+* [Docker best practices: image repository](https://getcarina.com/docs/best-practices/docker-best-practices-image-repository/)

--- a/_troubleshooting/2016-02-09-troubleshooting-swarm-affinity.md
+++ b/_troubleshooting/2016-02-09-troubleshooting-swarm-affinity.md
@@ -31,25 +31,25 @@ This error message indicates that the container was scheduled on a different seg
 than the segment that built the image, and therefore the image could not be found.
 To resolve this error, select one of the following options:
 
-* [Use Docker Swarm image affinity scheduling](#use-docker-swarm-image-affinity-scheduling)
+* [Use image affinity scheduling with Docker Swarm](#use-image-affinity-scheduling-with-docker-swarm)
 * [Use Docker Hub](#use-docker-hub)
 * [Use another public Docker registry](#use-a-public-docker-registry)
 * [Use a private Docker registry](#use-a-private-docker-registry)
 
-**Note**: This error will only occur after scaling your cluster to two or more segments.
+**Note**: This error occurs only after you scale your cluster to two or more segments.
 
-### Use Docker Swarm image affinity scheduling
-Specify `--env affinity:image==<custom-image>` when creating or running a container
-that uses `<custom-image>`. This instructs Docker Swarm to schedule the new
-container on a segment which has your custom image.
+### Use image affinity scheduling with Docker Swarm
+When you create or run a container that uses `<custom-image>`,
+specify `--env affinity:image==<custom-image>`. This command instructs Docker Swarm
+to schedule the new container on a segment that has your custom image.
 
 ```
 $ docker build -t <custom-image> .
-$ docker run --env affinity:image==<custom-image>
+$ docker run --env affinity:image==<custom-image> <custom-image>
 ```
 
 **Note**: If you need to run the container on multiple segments,
-then a Docker registry is required.
+then a Docker registry is required. See the following sections for options.
 
 <!-- In future versions of Docker Swarm the image affinity hint won't be necessary, because of
 https://github.com/docker/swarm/issues/743. However this article is still
@@ -58,7 +58,7 @@ useful because if you need to run on multiple segments
 
 ### Use Docker Hub
 Docker Hub is the default, official Docker registry. Carina can discover images on
-[Docker Hub](https://hub.docker.com/), without requiring any configuration
+[Docker Hub](https://hub.docker.com/) without requiring any configuration
 changes or command-line flags.
 
 1. Create a Docker Hub account.
@@ -85,7 +85,8 @@ changes or command-line flags.
     docker push <dockerhub-user>/<custom-image>
     ```
 
-1. Optionally, pull the custom image down to every segment in your cluster.
+1. _(Optional)_ Pull the custom image down to every segment in your cluster.
+    This step is optional because Carina automatically discovers Docker Hub images.
 
     ```
     $ docker pull <dockerhub-user>/<custom-image>
@@ -97,7 +98,7 @@ changes or command-line flags.
     Each segment in the cluster downloads the image from Docker Hub, improving
     the performance of subsequent `run` commands.
 
-1. Run a docker container using the custom image.
+1. Run a container using the custom image.
 
     ```
     docker run <dockerhub-user>/<custom-image>
@@ -110,7 +111,7 @@ to host your custom image.
 1. Create an account on a public Docker registry.
 
 1. Log in to the registry from the command line. Your credentials are saved to `~/.docker/config.json`.
-    Replace `<registry>` with the the registry's domain name, such as `quay.io`.
+    Replace `<registry>` with the registry's domain name, such as `quay.io`.
 
     ```
     $ docker login <registry>
@@ -149,7 +150,7 @@ to host your custom image.
     For example, if the image name is `quay.io/myuser/myrepo`, then each segment
     in the cluster pulls the image from the quay.io registry.
 
-1. Run a docker container using the custom image.
+1. Run a container using the custom image.
 
     ```
     docker run <registry>/<registry-user>/<custom-image>
@@ -157,10 +158,11 @@ to host your custom image.
 
 ### Use a private Docker registry
 In some cases, running your own private Docker registry directly on your cluster
-might be advantageous, especially when dealing with large images or images containing sensitive data.
+might be advantageous, especially when dealing with large images or images that contain sensitive data.
 
-1. Follow the [Store private Docker registry images on Rackspace Cloud Files](https://getcarina.com/docs/tutorials/registry-on-cloud-files/)
-    tutorial to set up a private Docker registry.
+1. Set up a private Docker registry by following the
+    [Store private Docker registry images on Rackspace Cloud Files]({{site.baseurl}}/docs/tutorials/registry-on-cloud-files/)
+    tutorial.
 
 1. Build your custom image.
 
@@ -187,7 +189,7 @@ might be advantageous, especially when dealing with large images or images conta
     For example, if the image name is `127.0.0.1:5000/myuser/myimage`,
     then each segment in the cluster pulls the image from your private registry.
 
-1. Run a docker container using the custom image.
+1. Run a container using the custom image.
 
     ```
     docker run 127.0.0.1:5000/<registry-user>/<custom-image>
@@ -195,5 +197,5 @@ might be advantageous, especially when dealing with large images or images conta
 
 ### Resources
 
-* [Understanding how Carina uses Docker Swarm](https://getcarina.com/docs/concepts/docker-swarm-carina/)
-* [Docker best practices: image repository](https://getcarina.com/docs/best-practices/docker-best-practices-image-repository/)
+* [Understanding how Carina uses Docker Swarm]({{site.baseurl}}/docs/concepts/docker-swarm-carina/)
+* [Docker best practices: image repository]({{site.baseurl}}/docs/best-practices/docker-best-practices-image-repository/)


### PR DESCRIPTION
Fixes #628. 

Fixes https://github.com/getcarina/feedback/issues/32

Explains how to either use image affinity or preferably a Docker registry for using custom images on a cluster with more than one segment.