### PR TITLE
Re-generate DH params in Letsencrypt tutorial

### DIFF
--- a/_tutorials/2016-02-03-nginx-with-lets-encrypt.md
+++ b/_tutorials/2016-02-03-nginx-with-lets-encrypt.md
@@ -366,6 +366,19 @@ When you're confident that your infrastructure is in place with staging certific
     ```
 
     These commands produce no output when successful.
+    
+1. The above command cleans out your pre-production letsencrypt certificates, but it also deletes the file containing the Diffie-Hellman parameters you generated earlier. NGINX will fail to reload if this file doesn't exist, so create the Diffie-Hellman parameters again.
+
+    ```bash
+    $ docker run \
+      --rm --interactive --tty \
+      --volumes-from letsencrypt-data \
+      nginx \
+      openssl dhparam -out /etc/letsencrypt/dhparams.pem 2048
+    Generating DH parameters, 2048 bit long safe prime, generator 2
+    This is going to take a long time
+    ............................
+    ```
 
 1. Run the Let's Encrypt client again, omitting the `--server` parameter, to acquire a production certificate. Because the NGINX container is still running, use the *webroot* authenticator this time.
 


### PR DESCRIPTION
@smashwilson In the NGINX with LetsEncrypt tutorial, the tutorial advises cleaning out the `/etc/letsencrypt` directory before transitioning from staging certificates to production ones. In the course of doing this, the file `/etc/letsencrypt/dhparams.pem` is also deleted, which is required by NGINX to start or reload its config.

I'm proposing that we instruct the reader to re-run the command that generates the Diffie-Hellman params. An alternative would be to amend the cleanup command (currently a pretty heavy-handed `rm -r /etc/letsencrypt/*`) to delete only what's really necessary from that directory, thus preserving the DH params file.