### PR TITLE
docs(cli): Add brew update to OSX cli instructions

### DIFF
--- a/_getting-started/2015-10-24-carina-cli.md
+++ b/_getting-started/2015-10-24-carina-cli.md
@@ -32,6 +32,7 @@ To download and install the `carina` CLI, use the appropriate instructions for y
 If you're using [Homebrew](http://brew.sh/), run the following command:
 
 ```bash
+$ brew update
 $ brew install carina
 ```
 


### PR DESCRIPTION
Simple one-line change to encourage users to do a "brew update" before the "brew install carina".