### PR TITLE
Content refresh for Let's Encrypt and NGINX tutorial.

### DIFF
--- a/_tutorials/2016-02-03-nginx-with-lets-encrypt.md
+++ b/_tutorials/2016-02-03-nginx-with-lets-encrypt.md
@@ -214,7 +214,7 @@ Construct an NGINX container that uses the issued TLS credentials and Diffie-Hel
     ```Dockerfile
     FROM nginx
 
-    COPY nginx.conf /etc/nginx/conf.d/default.conf
+    COPY default.conf /etc/nginx/conf.d/default.conf
     COPY index.html /data/www/index.html
     ```
 

--- a/_tutorials/2016-02-03-nginx-with-lets-encrypt.md
+++ b/_tutorials/2016-02-03-nginx-with-lets-encrypt.md
@@ -5,7 +5,7 @@ date: 2016-02-03
 permalink: docs/tutorials/nginx-with-lets-encrypt/
 description: Learn to secure an NGINX server with free TLS certificates from Let's Encrypt
 docker-versions:
-  - 1.9.1
+  - 1.10.1
 topics:
   - docker
   - intermediate

--- a/_tutorials/2016-02-03-nginx-with-lets-encrypt.md
+++ b/_tutorials/2016-02-03-nginx-with-lets-encrypt.md
@@ -214,7 +214,7 @@ Construct an NGINX container that uses the issued TLS credentials and Diffie-Hel
     ```Dockerfile
     FROM nginx
 
-    COPY default.conf /etc/nginx/conf.d/default.conf
+    COPY nginx.conf /etc/nginx/conf.d/default.conf
     COPY index.html /data/www/index.html
     ```
 
@@ -366,7 +366,7 @@ When you're confident that your infrastructure is in place with staging certific
     ```
 
     These commands produce no output when successful.
-    
+
 1. The above command cleans out your pre-production letsencrypt certificates, but it also deletes the file containing the Diffie-Hellman parameters you generated earlier. NGINX will fail to reload if this file doesn't exist, so create the Diffie-Hellman parameters again.
 
     ```bash


### PR DESCRIPTION
I'm giving the tutorial another runthrough from the top down and fixing whatever I find. I don't _think_ there's anything specific to change for Docker 1.10.1, though.

Fixes #711.