### PR TITLE
Replace the Deconst client instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,9 @@
 
 This [Jekyll](http://jekyllrb.com/) repository houses documentation and tutorials for Carina by Rackspace.
 
-## Installation
-You must use the [Deconst Client][deconst-client] to preview your changes.
+## Preview
 
-1. [Install Deconst Client][deconst-client].
-1. Clone this repository and the [Nexus Control][nexus-control] repository.
-1. Start the Deconst application.
-1. Click the New button.
-1. Set the content repository to getcarina.com.
-1. Set the preparer to Jekyll.
-1. In the Content Repository Path section, click the browse button, then navigate to the location where you cloned this repository.
-1. In the Control Repository Location, click the browse button, then navigate to hte lcoation where you cloned the Nexus Control repository.
-1. Click the Create button.
-1. Wait until the deconst process is complete, then click the displayed link to preview the site.
-
-    **Note:** If after 5 minutes you do not see a link and it is still in the preparing state, use [this workaround](https://github.com/deconst/client/issues/50) and add a comment that you have hit the bug as well.
-
-Deconst is now serving this repo as a simple website, and will rebuild the site every time you save a file.
-
-[deconst-client]: https://github.com/deconst/client
-[nexus-control]: https://github.com/rackerlabs/nexus-control
+A few minutes after you open a new pull request or push additional commits to an existing one, @rackernexus will post a comment including a link to a preview build of your content.
 
 ## Contact
 


### PR DESCRIPTION
The Deconst client has been outright broken for a while now, but we do have a pull-request builder now. We probably shouldn't point people to the client, at least for the moment.