### PR TITLE
add site domain to site-wide deconst_categories

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,9 @@ exclude:
 gems:
   - jekyll-paginate
 
+deconst_categories:
+  - getcarina.com
+
 paginate: 10
 paginate_path: /blog/page/:num
 excerpt_separator: "<!-- more -->"


### PR DESCRIPTION
Allows scoping search to only show results from a specific site.