### PR TITLE
Updating Getting Started doc to use 1.10.3

### DIFF
--- a/_getting-started/2015-10-25-getting-started-on-carina.md
+++ b/_getting-started/2015-10-25-getting-started-on-carina.md
@@ -6,7 +6,7 @@ featured: true
 permalink: docs/getting-started/getting-started-on-carina/
 description: Learn how to get your first containerized application up and running on Carina in a minimal amount of time
 docker-versions:
-  - 1.10.1
+  - 1.10.3
 topics:
   - docker
   - beginner
@@ -54,10 +54,10 @@ If you have any problems, see the [Troubleshooting](#troubleshooting) section.
 
     The name of the directory that is created is the same as the name of the cluster. For example, `Downloads/mycluster`.
 
-1. Download the Docker 1.10.1 client into the unzipped directory.
-    - On Linux, download the [Linux client](https://get.docker.com/builds/Linux/x86_64/docker-1.10.1) to `Downloads/mycluster`.
-    - On Mac OS X, download the [Mac client](https://get.docker.com/builds/Darwin/x86_64/docker-1.10.1) to `Downloads/mycluster`.
-    - On Windows, download the [Windows client](https://get.docker.com/builds/Windows/x86_64/docker-1.10.1.exe) to `Downloads/mycluster`.
+1. Download the Docker 1.10.3 client into the unzipped directory.
+    - On Linux, download the [Linux client](https://get.docker.com/builds/Linux/x86_64/docker-1.10.3) to `Downloads/mycluster`.
+    - On Mac OS X, download the [Mac client](https://get.docker.com/builds/Darwin/x86_64/docker-1.10.3) to `Downloads/mycluster`.
+    - On Windows, download the [Windows client](https://get.docker.com/builds/Windows/x86_64/docker-1.10.3.exe) to `Downloads/mycluster`.
 
 1. Open an application in which to run commands.
     - On Linux and Mac OS X, open a terminal.
@@ -72,7 +72,7 @@ If you have any problems, see the [Troubleshooting](#troubleshooting) section.
     ```bash
     $ cd Downloads/mycluster
     $ mkdir -p $HOME/bin
-    $ mv docker-1.10.1 $HOME/bin/docker
+    $ mv docker-1.10.3 $HOME/bin/docker
     $ chmod u+x $HOME/bin/docker
     $ export PATH=$HOME/bin:$PATH
     $ if [ -f ~/.bash_profile ]; then echo 'export PATH=$HOME/bin:$PATH' >> $HOME/.bash_profile; fi
@@ -84,7 +84,7 @@ If you have any problems, see the [Troubleshooting](#troubleshooting) section.
     ```
     $ cd Downloads\mycluster
     $ mkdir "$env:USERPROFILE\bin"
-    $ mv docker-1.10.1.exe "$env:USERPROFILE\bin\docker.exe"
+    $ mv docker-1.10.3.exe "$env:USERPROFILE\bin\docker.exe"
     $ $env:PATH += ";$env:USERPROFILE\bin"
     $ [Environment]::SetEnvironmentVariable("PATH", $env:PATH, "User")
     $ Set-ExecutionPolicy -Scope CurrentUser Unrestricted


### PR DESCRIPTION
Carina is now standing up clusters using Docker 1.10.3. This commit
just replaces references to 1.10.1 with 1.10.3 in the getting
started doc.