### PR TITLE
Fix secret generation instructions

### DIFF
--- a/_tutorials/2016-04-18-push-cd.md
+++ b/_tutorials/2016-04-18-push-cd.md
@@ -100,7 +100,7 @@ notifications and redeploys containers after their underlying image is updated.
 1. Generate a secret by running something like:
 
   ```
-  $ export SECRET=$(date | shasum | head -c 40)
+  $ export SECRET=$(xxd -l 20 -p /dev/urandom)
   ```
 
   or


### PR DESCRIPTION
The first example command given for generating a secret is highly insecure; it's not hard at all to brute-force a range of timestamps  with second precision, especially if you have some general idea when the secret generation is done. Here's an alternative suggestion that works on OS X and most Linux systems; it's probably not too common to have a system with neither vim (`xxd`) nor openssl installed..