### PR TITLE
Move dvm guide under reference

### DIFF
--- a/_includes/getting-started.md
+++ b/_includes/getting-started.md
@@ -133,6 +133,6 @@ For additional assistance, ask the [community](https://community.getcarina.com/)
 ### Resources
 
 * [Docker 101]({{ site.baseurl }}/docs/concepts/docker-101/)
-* [Docker Version Manager]({{ site.baseurl }}/docs/tutorials/docker-version-manager/)
+* [Docker Version Manager]({{ site.baseurl }}/docs/reference/docker-version-manager/)
 * [Carina CLI]({{ site.baseurl }}/docs/reference/carina-cli/)
 * [Use overlay networks in Carina]({{ site.baseurl }}/docs/tutorials/overlay-networks/)

--- a/_posts/2015-11-13-weekly-news-docker-1-9-dvm.md
+++ b/_posts/2015-11-13-weekly-news-docker-1-9-dvm.md
@@ -61,7 +61,7 @@ $ dvm ls
 	system (1.9.0)
 ```
 
-See the [DVM announcement](https://getcarina.com/blog/docker-version-manager/) and tutorial on [Managing Docker client versions with dvm](https://getcarina.com/docs/tutorials/docker-version-manager/) for more!
+See the [DVM announcement](https://getcarina.com/blog/docker-version-manager/) and tutorial on [Managing Docker client versions with dvm](https://getcarina.com/docs/reference/docker-version-manager/) for more!
 
 ## app.getcarina.com updates
 

--- a/_posts/2016-02-17-overlay-networks.md
+++ b/_posts/2016-02-17-overlay-networks.md
@@ -38,7 +38,7 @@ We strongly recommend using an overlay anytime you need two or more containers t
 
 ## Overlay network example
 
-To get a feel for how you can work with overlay networks on Carina, let’s run through an example. For this example, you need to [create and connect to a cluster]({{ site.baseurl }}/docs/getting-started/create-connect-cluster/) with at least two nodes. Overlay networks are available only on clusters created after February 15, 2016, and existing clusters cannot be upgraded to include overlay networks. If you find yourself juggling clusters with different Docker versions, we recommend that you [manage your Docker clients with the Docker Version Manager (dvm)]({{ site.baseurl }}/docs/tutorials/docker-version-manager/).
+To get a feel for how you can work with overlay networks on Carina, let’s run through an example. For this example, you need to [create and connect to a cluster]({{ site.baseurl }}/docs/getting-started/create-connect-cluster/) with at least two nodes. Overlay networks are available only on clusters created after February 15, 2016, and existing clusters cannot be upgraded to include overlay networks. If you find yourself juggling clusters with different Docker versions, we recommend that you [manage your Docker clients with the Docker Version Manager (dvm)]({{ site.baseurl }}/docs/reference/docker-version-manager/).
 
 Use the `docker network create` command to create an overlay network.
 

--- a/_posts/2016-02-19-new-in-swarm-we-give-you.md
+++ b/_posts/2016-02-19-new-in-swarm-we-give-you.md
@@ -53,7 +53,7 @@ you posted on that feature. We are happy we can now see errors from nodes that f
 the cluster. And if you want to play around with private registries and authentication,
 take a look at the [Swarm API docs](https://docs.docker.com/swarm/swarm-api/#registry-authentication).
 
-[Docker version manager](https://getcarina.com/docs/tutorials/docker-version-manager/)
+[Docker version manager](https://getcarina.com/docs/reference/docker-version-manager/)
 makes it so much easier to manage what versions you're running locally and switch between
 them as needed. This is a good week to install it!
 

--- a/_reference/2015-10-06-docker-version-manager.md
+++ b/_reference/2015-10-06-docker-version-manager.md
@@ -2,7 +2,7 @@
 title: Manage Docker client versions with dvm
 author: Carolyn Van Slyck <carolyn.vanslyck@rackspace.com>
 date: 2015-10-06
-permalink: docs/tutorials/docker-version-manager/
+permalink: docs/reference/docker-version-manager/
 description: Manage your Docker clients with the Docker Version Manager (dvm)
 topics:
   - Carina

--- a/_troubleshooting/2016-03-22-troubleshooting.md
+++ b/_troubleshooting/2016-03-22-troubleshooting.md
@@ -188,7 +188,7 @@ To resolve this error, upgrade PowerShell to version 3 or above.
 * [Troubleshooting the Docker Toolbox setup on Windows 7, 8.1, and 10]({{ site.baseurl }}/docs/troubleshooting/troubleshooting-windows-docker-vm-startup/)
 * [Error running interactive Docker shell on Windows]({{ site.baseurl }}/docs/troubleshooting/troubleshooting-cannot-enable-tty-mode-on-windows/)
 
-[dvm]: {{site.baseurl}}/docs/tutorials/docker-version-manager/
+[dvm]: {{site.baseurl}}/docs/reference/docker-version-manager/
 [carina-creds]: {{site.baseurl}}/docs/getting-started/create-connect-cluster/#connect-to-your-cluster
 [rebuild]: {{site.baseurl}}/docs/reference/faq/#how-do-i-rebuild-a-cluster
 [rebuild-do]: {{site.baseurl}}/docs/reference/faq/#what-does-the-cluster-rebuild-action-do

--- a/_tutorials/2016-05-09-migrate-cluster.md
+++ b/_tutorials/2016-05-09-migrate-cluster.md
@@ -24,7 +24,7 @@ This tutorial describes how to migrate to a new cluster to take advantage of new
 
 ### Install the Docker Version Manager
 
-Migrating to a new cluster likely means using a newer version of Docker. That means you will have two or more clusters with different versions of Docker. To make it easy to work with different versions of the Docker client, follow the tutorial to [manage Docker client versions with Docker Version Manager (dvm)]({{ site.baseurl }}/docs/tutorials/docker-version-manager/).
+Migrating to a new cluster likely means using a newer version of Docker. That means you will have two or more clusters with different versions of Docker. To make it easy to work with different versions of the Docker client, follow the tutorial to [manage Docker client versions with Docker Version Manager (dvm)]({{ site.baseurl }}/docs/reference/docker-version-manager/).
 
 ### Install the Carina CLI
 


### PR DESCRIPTION
The dvm guide is not a tutorial and belongs next to the new carina cli reference doc