### PR TITLE
fix swarm-data cert links in wiretap setup

### DIFF
--- a/_tutorials/2016-04-18-push-cd.md
+++ b/_tutorials/2016-04-18-push-cd.md
@@ -127,8 +127,8 @@ notifications and redeploys containers after their underlying image is updated.
     --volumes-from swarm-data \
     --env TOKEN=$SECRET \
     --env DOCKER_HOST=$DOCKER_HOST \
-    --env DOCKER_CERT_PATH=/etc/docker/server-cert.pem \
-    --env DOCKER_KEY_PATH=/etc/docker/server-key.pem \
+    --env DOCKER_CERT_PATH=/etc/docker/cert.pem \
+    --env DOCKER_KEY_PATH=/etc/docker/key.pem \
     --env DOCKER_CA_CERT_PATH=/etc/docker/ca.pem \
     carina/wiretap
   ```


### PR DESCRIPTION
When initially following the tutorial, I realized my wiretap container hadn't started because of missing cert files. Following the readme [here](https://github.com/getcarina/wiretap) I found the correct file paths.